### PR TITLE
use client.once over client.on

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -118,7 +118,7 @@ class InvitesTracker extends EventEmitter {
                     this.emit('cacheFetched');
                 });
             } else {
-                this.client.on('ready', () => {
+                this.client.once('ready', () => {
                     this.fetchCache().then(() => {
                         this.cacheFetched = true;
                         this.emit('cacheFetched');


### PR DESCRIPTION
Since `ready` will only be emitted once, use [`EventEmitter#once`](https://nodejs.org/api/events.html#emitteronceeventname-listener), which will dispose of the listener after the event has fired once.