### PR TITLE
Enforce all ESLint rules

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -15,7 +15,7 @@ module.exports = {
     ],
     rules: {
         'comma-dangle': ['error', 'never'],
-        'indent': ['error', 4],
+        indent: ['error', 4],
         'padded-blocks': 0,
         'lines-between-class-members': 0,
         'no-unused-vars': 'off',

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -14,8 +14,8 @@ module.exports = {
         '@typescript-eslint'
     ],
     rules: {
-        'comma-dangle': [ 'error', 'never' ],
-        'indent': [ 'error', 4 ],
+        'comma-dangle': ['error', 'never'],
+        'indent': ['error', 4],
         'padded-blocks': 0,
         'lines-between-class-members': 0,
         'no-unused-vars': 'off',

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,17 +1,17 @@
 module.exports = {
     env: {
         es2020: true,
-        node: true,
+        node: true
     },
     extends: [
-        'airbnb-base',
+        'airbnb-base'
     ],
     parser: '@typescript-eslint/parser',
     parserOptions: {
-        ecmaVersion: 11,
+        ecmaVersion: 11
     },
     plugins: [
-        '@typescript-eslint',
+        '@typescript-eslint'
     ],
     rules: {
         'comma-dangle': [ 'error', 'never' ],

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -20,6 +20,7 @@ module.exports = {
         'lines-between-class-members': 0,
         'no-unused-vars': 'off',
         '@typescript-eslint/no-unused-vars': 'error',
+        'linebreak-style': ['error', 'windows'],
         'max-len': 0
     }
 };

--- a/index.ts
+++ b/index.ts
@@ -236,7 +236,7 @@ class InvitesTracker extends EventEmitter {
     }
 
     public async fetchCache() {
-        const fetchGuildCachePromises = this.client.guilds.cache.map(guild => this.fetchGuildCache(guild));
+        const fetchGuildCachePromises = this.client.guilds.cache.map((guild) => this.fetchGuildCache(guild));
         await Promise.all(fetchGuildCachePromises);
     }
 

--- a/index.ts
+++ b/index.ts
@@ -44,7 +44,7 @@ interface VanityInviteData {
 interface DeletedInviteData extends InviteData {
     deleted?: boolean;
     deletedTimestamp?: number;
-};
+}
 
 type TrackedInviteData = DeletedInviteData & InviteData;
 

--- a/index.ts
+++ b/index.ts
@@ -189,7 +189,7 @@ class InvitesTracker extends EventEmitter {
         }
 
         // Ensuite, on compare le cache et les données actuelles (voir commentaires de la fonction)
-        let usedInvites = compareInvitesCache(cachedInvites, currentInvitesData);
+        const usedInvites = compareInvitesCache(cachedInvites, currentInvitesData);
 
         // L'invitation peut aussi être une invitation vanity (https://discord.gg/invitation-personnalisee)
         let isVanity = false;

--- a/index.ts
+++ b/index.ts
@@ -142,7 +142,7 @@ class InvitesTracker extends EventEmitter {
 
     private async handleInviteCreate(invite: Invite): Promise<void> {
         // Vérifier que le cache pour ce serveur existe bien
-        if(this.options.fetchGuilds) await this.fetchGuildCache(invite.guild as Guild, true);
+        if (this.options.fetchGuilds) await this.fetchGuildCache(invite.guild as Guild, true);
         // Ensuite, ajouter l'invitation au cache du serveur
         if (this.invitesCache.get(invite.guild!.id)) {
             this.invitesCache.get(invite.guild!.id)!.set(invite.code, InvitesTracker.mapInviteData(invite));
@@ -153,7 +153,7 @@ class InvitesTracker extends EventEmitter {
         // Récupère le cache du serveur
         const cachedInvites = this.invitesCache.get(invite.guild!.id);
         // Si le cache pour ce serveur existe et si l'invitation existe bien dans le cache de ce serveur
-        if(cachedInvites && cachedInvites.get(invite.code)) {
+        if (cachedInvites && cachedInvites.get(invite.code)) {
             cachedInvites.get(invite.code)!.deletedTimestamp = Date.now();
         }
     }

--- a/index.ts
+++ b/index.ts
@@ -140,7 +140,7 @@ class InvitesTracker extends EventEmitter {
         };
     }
 
-    private async handleInviteCreate (invite: Invite): Promise<void> {
+    private async handleInviteCreate(invite: Invite): Promise<void> {
         // Vérifier que le cache pour ce serveur existe bien
         if(this.options.fetchGuilds) await this.fetchGuildCache(invite.guild as Guild, true);
         // Ensuite, ajouter l'invitation au cache du serveur
@@ -149,7 +149,7 @@ class InvitesTracker extends EventEmitter {
         }
     }
 
-    private async handleInviteDelete (invite: Invite): Promise<void> {
+    private async handleInviteDelete(invite: Invite): Promise<void> {
         // Récupère le cache du serveur
         const cachedInvites = this.invitesCache.get(invite.guild!.id);
         // Si le cache pour ce serveur existe et si l'invitation existe bien dans le cache de ce serveur

--- a/index.ts
+++ b/index.ts
@@ -73,7 +73,7 @@ const compareInvitesCache = (cachedInvites: Collection<string, TrackedInviteData
     if (invitesUsed.length < 1) {
         // Triage du cache pour que les invitations supprimées le plus récemment soient en premier
         // (logiquement une invitation supprimée il y a 0.01s a plus de chance d'être une invitation que le membre a utilisé qu'une invitation supprimée il y a 3 jours)
-        cachedInvites.sort((a, b) => (a.deletedTimestamp && b.deletedTimestamp) ? b.deletedTimestamp - a.deletedTimestamp : 0).forEach((invite) => {
+        cachedInvites.sort((a, b) => ((a.deletedTimestamp && b.deletedTimestamp) ? b.deletedTimestamp - a.deletedTimestamp : 0)).forEach((invite) => {
             if (
                 // Si l'invitation n'est plus présente
                 !currentInvites.get(invite.code)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@androz2091/discord-invites-tracker",
-    "version": "1.2.3",
+    "version": "1.2.4",
     "main": "lib/index.js",
     "author": "Androz2091 <androz2091@gmail.com>",
     "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -11,10 +11,12 @@
         "@types/node": "^18.11.9",
         "@typescript-eslint/eslint-plugin": "^4.29.3",
         "@typescript-eslint/parser": "^4.29.3",
-        "discord.js": "^14.6.0",
         "dotenv": "^10.0.0",
         "eslint": "^7.32.0",
         "eslint-config-airbnb-base": "^14.2.1",
         "typescript": "^4.8.4"
+    },
+    "dependencies": {
+        "discord.js": "^14.6.0"
     }
 }


### PR DESCRIPTION
Fixed all ESLint errors according to [`.eslintrc.js`](https://github.com/Androz2091/discord-invites-tracker/blob/9f4b579610d743ef70afe7e29fab5eab3c29cf54/.eslintrc.js). Why have rules if they're not used?

Rules that got enforced:
- [`import/no-extraneous-dependencies`](https://github.com/import-js/eslint-plugin-import/blob/cd957286efe1c4aa0423f82ac5576c75fd3be71e/docs/rules/no-extraneous-dependencies.md)
- [`keyword-spacing`](https://eslint.org/docs/latest/rules/keyword-spacing)
- [`space-before-function-paren`](https://eslint.org/docs/latest/rules/space-before-function-paren)
- [`prefer-const`](https://eslint.org/docs/latest/rules/prefer-const)
- [`arrow-parens`](https://eslint.org/docs/latest/rules/arrow-parens)
- [`no-confusing-arrow`](https://eslint.org/docs/latest/rules/no-confusing-arrow)
- [`semi`](https://eslint.org/docs/latest/rules/semi)
- [`quote-props`](https://eslint.org/docs/latest/rules/quote-props)
- [`array-bracket-spacing`](https://eslint.org/docs/latest/rules/array-bracket-spacing)
- [`comma-dangle`](https://eslint.org/docs/latest/rules/comma-dangle)

I also added the rule [`linebreak-style`](https://eslint.org/docs/latest/rules/linebreak-style) to allow the existing line-breaks instead of changing every line-break in the project.
And i patched the version, allowing the package to be published to [npm](https://www.npmjs.com/package/discord-invites-tracker).